### PR TITLE
Add a link to fluentd.org in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# fluent-plugin-secure-forward
+# fluent-plugin-secure-forward, a plugin for [Fluentd](http://fluentd.org)
 
 Fluentd input/output plugin to forward fluentd messages over SSL with authentication.
 


### PR DESCRIPTION
I am adding a link to Fluentd.org in your README.md file to put Fluentd in context for newcomers.
