### PR TITLE
Add a link to fluentd.org in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# fluent-plugin-secure-forward, a plugin for [Fluentd](http://fluentd.org)
+# fluent-plugin-secure-forward
 
-Fluentd input/output plugin to forward fluentd messages over SSL with authentication.
+[Fluentd](http://fluentd.org) input/output plugin to forward fluentd messages over SSL with authentication.
 
 This plugin makes you to be able to:
 


### PR DESCRIPTION
I am adding a link to Fluentd.org in your README.md file to put Fluentd in context for newcomers.
