### PR TITLE
Fix client whitelisting for log input

### DIFF
--- a/lib/fluent/plugin/input_session.rb
+++ b/lib/fluent/plugin/input_session.rb
@@ -150,7 +150,7 @@ class Fluent::SecureForwardInput::Session
       return
     end
 
-    proto, port, host, ipaddr = @socket.io.addr
+    proto, port, host, ipaddr = @socket.io.peeraddr
     @node = check_node(host, ipaddr, port, proto)
     if @node.nil? && (! @receiver.allow_anonymous_source)
       $log.warn "Connection required from unknown host '#{host}' (#{ipaddr}), disconnecting..."


### PR DESCRIPTION
When receiving a new connection, the code was checking the local ip address to see if it was allowed,
This fixes it to look at the remote ip address.
