### PR TITLE
Node watcher monitor for detached state

### DIFF
--- a/lib/fluent/plugin/out_secure_forward.rb
+++ b/lib/fluent/plugin/out_secure_forward.rb
@@ -141,7 +141,7 @@ module Fluent
         (0...nodes_size).each do |i|
           log.trace "node health watcher for #{@nodes[i].host}"
 
-          next if @nodes[i].established? && ! @nodes[i].expired?
+          next if @nodes[i].established? && ! @nodes[i].expired? && ! @nodes[i].detached?
 
           next if reconnectings[i]
 
@@ -153,7 +153,7 @@ module Fluent
           end
 
           node = @nodes[i]
-          log.debug "reconnecting to node", :host => node.host, :port => node.port, :expire => node.expire, :expired => node.expired?
+          log.debug "reconnecting to node", :host => node.host, :port => node.port, :expire => node.expire, :expired => node.expired?, :detached => node.detached?
 
           renewed = node.dup
           renewed.start

--- a/lib/fluent/plugin/output_node.rb
+++ b/lib/fluent/plugin/output_node.rb
@@ -296,6 +296,8 @@ class Fluent::SecureForwardOutput::Node
       end
     end
     while @writing
+      break if @detach
+
       sleep read_interval
     end
     self.shutdown


### PR DESCRIPTION
This change set allows a node to be recovered by the node watcher after an EPIPE exception has caused the node to enter a detached state. The node is then managed in the same way as normal disconnection and ssl session is then restored by health watcher.