### PR TITLE
Check message format to prevent plugin from crashing

### DIFF
--- a/lib/fluent/plugin/in_secure_forward.rb
+++ b/lib/fluent/plugin/in_secure_forward.rb
@@ -256,7 +256,12 @@ module Fluent
     def on_message(msg)
       # NOTE: copy&paste from Fluent::ForwardInput#on_message(msg)
 
-      # TODO: format error
+      # Expect a msgpack FixArray of length 2
+      unless msg.kind_of?(Array) and msg.length == 2
+        log.warn("Discarding invalid message")
+        return
+      end
+
       tag = msg[0].to_s
       entries = msg[1]
 


### PR DESCRIPTION
We were running into this issue quite a bit in a production system, and I added debug messages:

```
2015-12-18 00:38:43 +0000 [warn]: unexpected error in in_secure_forward error_class=NoMethodError error=#<NoMethodError: undefined method `[]' for true:TrueClass>
2015-12-18 00:38:43 +0000 [warn]: error caused from x.x.x.x:34968
2015-12-18 00:38:43 +0000 [warn]: Backtrace: ["/opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluent-plugin-secure-forward-0.3.3/lib/fluent/plugin/in_secure_forward.rb:260:in `on_message'", "/opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluent-plugin-secure-forward-0.3.3/lib/fluent/plugin/input_session.rb:124:in `on_read'", "/opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluent-plugin-secure-forward-0.3.3/lib/fluent/plugin/input_session.rb:185:in `feed_each'", "/opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluent-plugin-secure-forward-0.3.3/lib/fluent/plugin/input_session.rb:185:in `block in start'", "/opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluent-plugin-secure-forward-0.3.3/lib/fluent/plugin/input_session.rb:178:in `loop'", "/opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluent-plugin-secure-forward-0.3.3/lib/fluent/plugin/input_session.rb:178:in `start'"]
```

This seems to happen when connections break in the middle of a transfer, causing a bad payload.