### PR TITLE
Detach node upon read error

### DIFF
--- a/lib/fluent/plugin/output_node.rb
+++ b/lib/fluent/plugin/output_node.rb
@@ -334,9 +334,13 @@ class Fluent::SecureForwardOutput::Node
         sleep socket_interval
       rescue SystemCallError => e
         log.warn "disconnected by Error", error_class: e.class, error: e, host: @host, port: @port
+        self.release!
+        self.detach!
         break
       rescue EOFError
         log.warn "disconnected", host: @host, port: @port
+        self.release!
+        self.detach!
         break
       end
     end


### PR DESCRIPTION
In certain situations, a node could be stuck in a state where it is never shut down, causing "no one nodes with valid SSL session" messages to be repeated endlessly in the logs.

Closes #21