### PR TITLE
Remove dependency on fluent/mixin/config_placeholders

### DIFF
--- a/lib/fluent/plugin/in_secure_forward.rb
+++ b/lib/fluent/plugin/in_secure_forward.rb
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-require 'fluent/mixin/config_placeholders'
 
 module Fluent
   class SecureForwardInput < Input
@@ -18,8 +17,8 @@ module Fluent
 
     config_param :secure, :bool # if secure, cert_path or ca_cert_path required
 
+    config_param :hostname, :string, default: nil
     config_param :self_hostname, :string
-    include Fluent::Mixin::ConfigPlaceholders
 
     config_param :shared_key, :string, secret: true
 
@@ -91,8 +90,29 @@ module Fluent
       define_method("router") { Fluent::Engine }
     end
 
+    def replace_hostname_placeholder(conf)
+      hostname = @hostname ? @hostname : Socket.gethostname
+
+      placeholders = ['__HOSTNAME__', '${hostname}']
+
+
+      check_element = ->(placeholders, c) {
+        c.keys.each do |k|
+          v = c.fetch(k, nil)
+          if v and placeholders.include? v
+            c[k] = hostname
+          end
+        end
+        c.elements.each{|e| check_element.call(placeholders,e)}
+      }
+      check_element.call(placeholders,conf)
+
+    end
+
     def configure(conf)
       super
+
+      replace_hostname_placeholder(conf)
 
       if @secure
         unless @cert_path || @ca_cert_path


### PR DESCRIPTION
Hostname placeholder `__HOSTNAME__` or `${hostname}` will be expanded to `#{Socket.gethostname}` or to value specified in `hostname` field. 

fixes https://github.com/tagomoris/fluent-plugin-secure-forward/issues/38
Please let me know what you think.

/a bit of offtopic/
When I run with trace on I get a bunch of errors. Although data seem to be getting in. Is that a problem?
```
2016-06-09 13:36:02 -0400 [trace]: plugin/output_node.rb:347:rescue in block in connect: SSLError error_class=OpenSSL::SSL::SSLErrorWaitReadable error=#<OpenSSL::SSL::SSLErrorWaitReadable: read would block> mtime=2016-06-09 13:35:55 -0400 host="10.3.14.104" port=24284
2016-06-09 13:36:02 -0400 [trace]: plugin/output_node.rb:347:rescue in block in connect: SSLError error_class=OpenSSL::SSL::SSLErrorWaitReadable error=#<OpenSSL::SSL::SSLErrorWaitReadable: read would block> mtime=2016-06-09 13:35:55 -0400 host="10.3.14.104" port=24284
```