### PR TITLE
Catch DNS related error to avoid thread abort

### DIFF
--- a/lib/fluent/plugin/output_node.rb
+++ b/lib/fluent/plugin/output_node.rb
@@ -231,7 +231,7 @@ class Fluent::SecureForwardOutput::Node
       addr = @sender.hostname_resolver.getaddress(@host)
       log.debug "create tcp socket to node", host: @host, address: addr, port: @port
     rescue => e
-      log.warn "failed to resolve the hostname", error_class: e.class, error: e, host: @host, address: addr, port: @port
+      log.warn "failed to resolve the hostname", error_class: e.class, error: e, host: @host
       @state = :failed
       return
     end

--- a/lib/fluent/plugin/output_node.rb
+++ b/lib/fluent/plugin/output_node.rb
@@ -227,8 +227,14 @@ class Fluent::SecureForwardOutput::Node
     Thread.current.abort_on_exception = true
     log.debug "starting client"
 
-    addr = @sender.hostname_resolver.getaddress(@host)
-    log.debug "create tcp socket to node", host: @host, address: addr, port: @port
+    begin
+      addr = @sender.hostname_resolver.getaddress(@host)
+      log.debug "create tcp socket to node", host: @host, address: addr, port: @port
+    rescue => e
+      log.warn "failed to resolve the hostname", error_class: e.class, error: e, host: @host, address: addr, port: @port
+      @state = :failed
+      return
+    end
 
     begin
       if @proxy_uri.nil? then


### PR DESCRIPTION
From fluentd issue: https://github.com/fluent/fluentd/issues/1144

I'm not sure don't catch DNS error is intended or not.