### PR TITLE
fix to rescue EBADF for broken/inconsistent SSL sessions

### DIFF
--- a/lib/fluent/plugin/out_secure_forward.rb
+++ b/lib/fluent/plugin/out_secure_forward.rb
@@ -263,7 +263,7 @@ module Fluent
       begin
         send_data(node, tag, es)
         node.release!
-      rescue Errno::EPIPE, IOError, OpenSSL::SSL::SSLError => e
+      rescue Errno::EBADF, Errno::EPIPE, IOError, OpenSSL::SSL::SSLError => e
         log.warn "Failed to send messages to #{node.host}, parging.", error_class: e.class, error: e
         node.release!
         node.detach!


### PR DESCRIPTION
Once SSL sessions went to inconsistent state by unstable networking, sending data into that SSLSocket may raise Errno::EBADF.
Currently, it's not rescued, and broken socket/output_node instance remains `@nodes`, and makes further (unexpected) errors.

This change is to fix this problem.
