### PR TITLE
support SNI in output plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,6 +398,36 @@ set for `proxy_uri` in `<server>` section:
 </match>
 ```
 
+#### Server Name Indication (SNI)
+
+You may need to pass the hostname to use for SNI
+<https://tools.ietf.org/html/rfc3546#section-3.1> if you are connecting through
+a proxy.  If your version of openssl supports SNI
+<https://www.openssl.org/docs/man1.1.0/ssl/SSL_SESSION_get0_hostname.html>, you
+can use this when connecting to a remote server.  Specify the `sni_hostname`
+parameter in your `<server>` section:
+
+```apache
+<match secret.data.**>
+  @type secure_forward
+  shared_key secret_string
+  self_hostname client.fqdn.local
+  
+  secure yes
+  # and configurations for certs/verification
+  
+  keepalive 3600
+  <server>
+    host server.fqdn.local  # or IP
+    sni_hostname secure.forward.listener.fqdn
+    # port 24284
+  </server>
+</match>
+```
+
+If you specify `sni_hostname` but your version of openssl does not support it,
+you will get a warning.
+
 ## Scenario (developer document)
 
 * server

--- a/lib/fluent/plugin/out_secure_forward.rb
+++ b/lib/fluent/plugin/out_secure_forward.rb
@@ -56,6 +56,7 @@ module Fluent
     config_section :server, param_name: :servers do
       config_param :host, :string
       config_param :hostlabel, :string, default: nil
+      config_param :sni_hostname, :string, default: nil
       config_param :port, :integer, default: DEFAULT_SECURE_CONNECT_PORT
       config_param :shared_key, :string, default: nil, secret: true
       config_param :username, :string, default: ''


### PR DESCRIPTION
Certain deployments that use a proxy may need to use SNI.  This
patch adds a new parameter `sni_hostname` to the `<server>` section
for the output plugin.  This can only be used if the version of
openssl used supports it.  A warning will be issued if openssl does
not support SNI and `sni_hostname` is attempted to be used.