### PR TITLE
Use OpenSSL::Cipher instead of OpenSSL::Cipher::Cipher to create cipher

### DIFF
--- a/bin/secure-forward-ca-generate
+++ b/bin/secure-forward-ca-generate
@@ -22,7 +22,7 @@ opt = {
 }
 cert, key = Fluent::SecureForward::CertUtil.generate_ca_pair(opt)
 
-key_data = key.export(OpenSSL::Cipher::Cipher.new('aes256'), passphrase)
+key_data = key.export(OpenSSL::Cipher.new('aes256'), passphrase)
 File.open(File.join(ca_dir, 'ca_key.pem'), 'w') do |file|
   file.write key_data
 end


### PR DESCRIPTION
On Ruby 2.4.1, `secure-forward-ca-generate` command generates a warning like the following
```
fluent-plugin-secure-forward/bin/secure-forward-ca-generate:25: warning: constant OpenSSL::Cipher::Cipher is deprecated
```

I confirmed that this patch works on Ruby 1.9.3-p551 too.