### PR TITLE
Fixed hostname resolution when using proxy

### DIFF
--- a/lib/fluent/plugin/output_node.rb
+++ b/lib/fluent/plugin/output_node.rb
@@ -228,23 +228,22 @@ class Fluent::SecureForwardOutput::Node
     log.debug "starting client"
 
     begin
-      addr = @sender.hostname_resolver.getaddress(@host)
-      log.debug "create tcp socket to node", host: @host, address: addr, port: @port
-    rescue => e
-      log.warn "failed to resolve the hostname", error_class: e.class, error: e, host: @host
-      @state = :failed
-      return
-    end
-
-    begin
       if @proxy_uri.nil? then
+        begin
+          addr = @sender.hostname_resolver.getaddress(@host)
+          log.debug "create tcp socket to node", host: @host, address: addr, port: @port
+        rescue => e
+          log.warn "failed to resolve the hostname", error_class: e.class, error: e, host: @host
+          @state = :failed
+          return
+        end
         sock = TCPSocket.new(addr, @port)
       else
         proxy = Proxifier::Proxy(@proxy_uri)
-        sock = proxy.open(addr, @port)
+        sock = proxy.open(@host, @port)
       end
     rescue => e
-      log.warn "failed to connect for secure-forward", error_class: e.class, error: e, host: @host, address: addr, port: @port
+      log.warn "failed to connect for secure-forward", error_class: e.class, error: e, host: @host, port: @port
       @state = :failed
       return
     end


### PR DESCRIPTION
Leaving hostname resolution to the Proxifier, because it allows a socks proxy to resolve the hostname instead of the locally configured DNS server.
This makes it possible to send data to a Tor .onion service as well.